### PR TITLE
Support for the outbound 'validate' function.

### DIFF
--- a/app/templates/spec/outbound-spec.coffee
+++ b/app/templates/spec/outbound-spec.coffee
@@ -5,6 +5,34 @@ outbound = require '../src/outbound'
 
 describe 'Outbound', ->
 
+  describe 'validation', ->
+    <% fields.forEach(function(field) { %>
+    describe 'of <%= field.id %>', ->
+
+      beforeEach ->
+        @vars = <% Object.keys(vars).filter(function(name) { return name !== 'lead' }).forEach(function(key) { %>
+          <%= key %>: <% Object.keys(vars[key]).forEach(function(name) {%>
+            <%= name %>: '<%= vars[key][name] %>' <% })}) %>
+          lead: fields.buildLeadVars <% Object.keys(vars.lead).filter(function(name){ return name !== field.id; }).forEach(function(name) { %>
+            <%= name %>: '<%= vars.lead[name] %>' <% }) %>
+
+      it 'should not allow null', ->
+        @vars.lead.<%= field.id %> = null
+        error = outbound.validate(@vars)
+        assert.equal error, 'lead.<%= field.id %> must not be blank'
+
+      it 'should not allow undefined', ->
+        error = outbound.validate(@vars)
+        assert.equal error, 'lead.<%= field.id %> must not be blank'
+
+      it 'should not allow empty', ->
+        @vars.lead.<%= field.id %> = ''
+        error = outbound.validate(@vars)
+        assert.equal error, 'lead.<%= field.id %> must not be blank'
+
+    <% }) %>
+
+
   describe 'request', ->
 
     beforeEach ->

--- a/app/templates/src/outbound.coffee
+++ b/app/templates/src/outbound.coffee
@@ -30,6 +30,23 @@ request.variables = ->
   ]
 
 
+
+#
+# Validate Function ------------------------------------------------------
+#
+
+#
+# This optional function validates the variables that will be passed to the request() function.
+# If the validate function returns anything other than null or undefined, the integration will be
+# skipped. When a string is returned, it will be revealed to the user as the reason that
+# the skip occurred.
+#
+
+validate = (vars) -><% fields.forEach(function(field) { %>
+  return 'lead.<%= field.id %> must not be blank' if !vars.lead.<%= field.id %>? or vars.lead.<%= field.id %>.toString() == ''<% }) %>
+
+
+
 #
 # Response Function ------------------------------------------------------
 #
@@ -61,8 +78,10 @@ response.variables = ->
 #
 
 #
-# Your integration module must export the request and response function.
+# Your integration module must export the request and response function. The
+# validate function is optional.
 #
 module.exports =
+  validate: validate
   request: request
   response: response


### PR DESCRIPTION
This is meant to resolve issue #5.

The generated validate function looks like this:

``` coffeescript
#
# Validate Function ------------------------------------------------------
#

#
# This optional function validates the variables that will be passed to the request() function.
# If the validate function returns anything other than null or undefined, the integration will be
# skipped. When a string is returned, it will be revealed to the user as the reason that
# the skip occurred.
#

validate = (vars) ->
  return 'lead.first_name must not be blank' if !vars.lead.first_name? or vars.lead.first_name.toString() == ''
  return 'lead.last_name must not be blank' if !vars.lead.last_name? or vars.lead.last_name.toString() == ''
  return 'lead.email must not be blank' if !vars.lead.email? or vars.lead.email.toString() == ''
  return 'lead.phone_1 must not be blank' if !vars.lead.phone_1? or vars.lead.phone_1.toString() == ''
  return 'lead.phone_2 must not be blank' if !vars.lead.phone_2? or vars.lead.phone_2.toString() == ''
```
